### PR TITLE
fix: prevent bib counter from exceeding maxDigits (#25)

### DIFF
--- a/convex/bibs.ts
+++ b/convex/bibs.ts
@@ -80,7 +80,9 @@ export const generate = mutation({
         for (let i = 0; i < 100; i++) {
             nextCount++;
             if (nextCount > maxNumber) {
-                throw new Error("Bib number range exhausted");
+                throw new Error(
+                    `Bib number range exhausted for category ${args.categoryId} (max ${maxDigits}-digit number is ${maxNumber})`
+                );
             }
             const padded = String(nextCount).padStart(maxDigits, "0");
             const formatted = formatBib(padded);

--- a/convex/bibs.ts
+++ b/convex/bibs.ts
@@ -74,9 +74,14 @@ export const generate = mutation({
         let nextCount = counter!.count;
         let finalBib = "";
 
+        const maxNumber = Math.pow(10, maxDigits) - 1;
+
         // Scan up to 100 candidates entirely in memory (no per-iteration DB round-trips)
         for (let i = 0; i < 100; i++) {
             nextCount++;
+            if (nextCount > maxNumber) {
+                throw new Error("Bib number range exhausted");
+            }
             const padded = String(nextCount).padStart(maxDigits, "0");
             const formatted = formatBib(padded);
 


### PR DESCRIPTION
## Summary
- Adds a guard in the sequential bib generation loop that throws `"Bib number range exhausted"` when the counter exceeds the max representable number for the configured `maxDigits` (e.g., 9999 for 4 digits)
- Prevents producing bib numbers with more digits than the event format allows

## Test plan
- [ ] Register participants until the bib counter approaches the max for the configured `maxDigits`
- [ ] Verify that exceeding the limit throws a clear error instead of producing an oversized bib number

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)